### PR TITLE
Added missing uploadStream method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -77,6 +77,14 @@ module.exports = {
         // eslint-disable-next-line no-param-reassign
         file.url = getUrl(file);
       },
+      uploadStream: async (file) => {
+        const metaData = {
+          "Content-Type": file.mime,
+        };
+        await minio.putObject(config.bucket, getFilename(file), file.stream, metaData);
+        // eslint-disable-next-line no-param-reassign
+        file.url = getUrl(file);
+      },
       delete: (file) => {
         minio.removeObject(config.bucket, getFilename(file));
       },


### PR DESCRIPTION
Using your plugin on my project, I got this error on strapi startup:

```(node:110) Warning: The upload provider "strapi-provider-upload-ts-minio" doesn't implement the uploadStream function. Strapi will fallback on the upload method. Some performance issues may occur.```

I added the function.

Thanks, and have a good day!

